### PR TITLE
Remove space before method invocation in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,12 +444,12 @@ Inside a code block, put the opening brace on the same line as the statement:
 
 ```csharp
 // Lovely.
-if (you.Love (someone)) {
+if (you.Love(someone)) {
 	someone.SetFree();
 }
 
 // Wrong.
-if (you.Love (someone))
+if (you.Love(someone))
 {
 	someone.SetFree();
 }
@@ -459,11 +459,11 @@ Omitting braces for single line if statements is fine, however braces are always
 
 ```csharp
 // Lovely.
-if (you.Like (it))
+if (you.Like(it))
 	it.PutOn(ring);
 
 // Acceptable.
-if (you.Like (it)) {
+if (you.Like(it)) {
 	it.PutOn(ring);
 }
 ```


### PR DESCRIPTION
Per self-same style guide, removed the space before 4 method invocations
in the examples.